### PR TITLE
[fix #30] Add .gitlab-ci.yml file.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,35 +1,38 @@
 stages:
   - deploy
+  - test
 
 .deploy:
   stage: deploy
-  retry:
-    max: 1  # Add one retry, especially for acceptance-tests
-    when: always
   tags:
     - aws
     - meao
   script:
     - kubectl_1.11 apply -f ${DEPLOYMENT}
     - ./rollout-status.sh ${DEPLOYMENT}
-    - ./acceptance-tests.sh ${URL}
 
 deploy oregon-a dev:
   extends: .deploy
   variables:
     DEPLOYMENT: oregon-a/basket-dev
     KUBECONFIG: /home/gitlab-runner/.kube/oregon-a.kubeconfig
-    URL: https://basket-dev.oregon-a.moz.works
-  only:
-    changes:
-      - "oregon-a/basket-dev/*"
+#  only:
+#    changes:
+#      - "oregon-a/basket-dev/*"
 
 deploy oregon-b dev:
   extends: .deploy
   variables:
     DEPLOYMENT: oregon-b/basket-dev
     KUBECONFIG: /home/gitlab-runner/.kube/oregon-b.kubeconfig
-    URL: https://basket-dev.oregon-b.moz.works
   only:
     changes:
       - "oregon-b/basket-dev/*"
+
+test dev:
+  stage: test
+  retry:
+    max: 1  # Add one retry, especially for acceptance-tests
+    when: always
+  script:
+    - ./acceptance-tests.sh http://basket-dev.moz.works/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,9 +16,9 @@ deploy oregon-a dev:
   variables:
     DEPLOYMENT: oregon-a/basket-dev
     KUBECONFIG: /home/gitlab-runner/.kube/oregon-a.kubeconfig
-#  only:
-#    changes:
-#      - "oregon-a/basket-dev/*"
+  only:
+    changes:
+      - "oregon-a/basket-dev/*"
 
 deploy oregon-b dev:
   extends: .deploy
@@ -34,5 +34,8 @@ test dev:
   retry:
     max: 1  # Add one retry, especially for acceptance-tests
     when: always
+  tags:
+    - aws
+    - meao
   script:
     - ./acceptance-tests.sh http://basket-dev.moz.works/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,35 @@
+stages:
+  - deploy
+
+.deploy:
+  stage: deploy
+  retry:
+    max: 1  # Add one retry, especially for acceptance-tests
+    when: always
+  tags:
+    - aws
+    - meao
+  script:
+    - kubectl_1.11 apply -f ${DEPLOYMENT}
+    - ./rollout-status.sh ${DEPLOYMENT}
+    - ./acceptance-tests.sh ${URL}
+
+deploy oregon-a dev:
+  extends: .deploy
+  variables:
+    DEPLOYMENT: oregon-a/basket-dev
+    KUBECONFIG: /home/gitlab-runner/.kube/oregon-a.kubeconfig
+    URL: https://basket-dev.oregon-a.moz.works
+  only:
+    changes:
+      - "oregon-a/basket-dev/*"
+
+deploy oregon-b dev:
+  extends: .deploy
+  variables:
+    DEPLOYMENT: oregon-b/basket-dev
+    KUBECONFIG: /home/gitlab-runner/.kube/oregon-b.kubeconfig
+    URL: https://basket-dev.oregon-b.moz.works
+  only:
+    changes:
+      - "oregon-b/basket-dev/*"

--- a/rollout-status.sh
+++ b/rollout-status.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for DEPLOY in $1/*-deploy.yaml; do
+    kubectl_1.11 rollout status -f ${DEPLOY}
+done


### PR DESCRIPTION
- Also add shell script to check rollout status of all deployments.

Note that `https://basket-dev.oregon-a.moz.works` is currently a 503, which I believe is purposeful (if not permanent). Will the scripts contained here re-enable it? If not, what should we do?