### PR TITLE
Unversion kubectl

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ stages:
     - aws
     - meao
   script:
-    - kubectl_1.11 apply -f ${DEPLOYMENT}
+    - kubectl apply -f ${DEPLOYMENT}
     - ./rollout-status.sh ${DEPLOYMENT}
 
 deploy oregon-a dev:

--- a/rollout-status.sh
+++ b/rollout-status.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 for DEPLOY in $1/*-deploy.yaml; do
-    kubectl_1.11 rollout status -f ${DEPLOY}
+    kubectl rollout status -f ${DEPLOY}
 done


### PR DESCRIPTION
I think it makes more sense to manage the default kubectl version on the gitlab runners rather than calling an explicit version in each CI/CD pipeline. Our clusters are all currently on k8s 1.13.x, as are the kubectl version installed on the runners.